### PR TITLE
remove the confusing content identifier in the canonical issue name

### DIFF
--- a/json/newspaper/issue.schema.json
+++ b/json/newspaper/issue.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "id": {
             "type": "string",
-            "description": "Canonical ID of the newspaper issue (e.g. GDL-1900-01-02-a-i0001)"
+            "description": "Canonical ID of the newspaper issue (e.g. GDL-1900-01-02-a)"
         },
         "cdt": {
             "type": "string",


### PR DESCRIPTION
Make schema example correspond to actual examples